### PR TITLE
Allow for omniauth 2.0 series

### DIFF
--- a/lib/omniauth-freee/version.rb
+++ b/lib/omniauth-freee/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Freee
-    VERSION = "0.0.4"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/omniauth/strategies/freee.rb
+++ b/lib/omniauth/strategies/freee.rb
@@ -31,7 +31,7 @@ module OmniAuth
       end
 
       def callback_url
-        full_host + script_name + callback_path
+        full_host + callback_path
       end
     end
   end

--- a/omniauth-freee.gemspec
+++ b/omniauth-freee.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Freee::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.5'
-  gem.add_dependency 'omniauth-oauth2', '>= 1.4.0', '< 2.0'
+  gem.add_dependency 'omniauth', '~> 2.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.7.1'
   gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'simplecov'

--- a/spec/omniauth/strategies/freee_spec.rb
+++ b/spec/omniauth/strategies/freee_spec.rb
@@ -63,12 +63,12 @@ describe OmniAuth::Strategies::Freee do
     end
   end
 
-  # describe '#callback_url' do
-  #   it 'is a combination of host, script name, and callback path' do
-  #     allow(subject).to receive(:full_host).and_return('https://example.com')
-  #     allow(subject).to receive(:script_name).and_return('/sub_uri')
+  describe '#callback_url' do
+    it 'is a combination of host, script name, and callback path' do
+      allow(subject).to receive(:full_host).and_return('https://example.com')
+      allow(subject).to receive(:script_name).and_return('/sub_uri')
 
-  #     expect(subject.callback_url).to eq('https://example.com/sub_uri/auth/freee/callback')
-  #   end
-  # end
+      expect(subject.callback_url).to eq('https://example.com/sub_uri/auth/freee/callback')
+    end
+  end
 end


### PR DESCRIPTION
Hi, @kkanazaw 

OmniAuth 2.0 was released includes to resolved a CSRF vulnerability and some behaviors changed.

See below the release note for details.
https://github.com/omniauth/omniauth/releases/tag/v2.0.0

This PR allow for OmniAuth 2.0 series.

I tested manually in remote server with https communication environment, and confirmed following.
  - should use omniauth 2.0 series.
  - should return credentials in auth hash. (regression scenarios)

If you want to try my branch, you can use like following in your Gemfile.
```rb
gem 'omniauth-freee', github: 'koshilife/omniauth-freee', branch: 'allow-for-omniauth-2.0'
```